### PR TITLE
fix(react): PivotUI widgets erased by autoClear — release as 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [2.0.1] — 2026-07-07
+
+### Fixed
+
+- `<PivotUI>` widgets were invisible in games that re-render every frame with `<PivotCanvas autoClear>` — the rAF repaint raced with the render-phase clear, so the UI was erased before every paint. `PivotUI` now also repaints in a per-render effect (running after sibling shape effects when placed as the last child), keeping the UI on top in both static and per-frame-render games.
+
+### Changed
+
+- Rollup build banner now reads the version from `package.json` instead of a hardcoded string.
+
+---
+
 ## [2.0.0] — 2026-07-07
 
 ### Added — Core

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@colon-dev/pivotx",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@colon-dev/pivotx",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@colon-dev/pivotx",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Lightweight 2D game development library — Vanilla JS, TypeScript, React & React Native / Expo",
   "author": "sachithamh@gmail.com",
   "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,11 +2,14 @@ import typescript from '@rollup/plugin-typescript';
 import resolve    from '@rollup/plugin-node-resolve';
 import terser     from '@rollup/plugin-terser';
 import dts        from 'rollup-plugin-dts';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
 
 const tsPlugin = () => typescript({ tsconfig: './tsconfig.json' });
 
 const banner = `/*!
- * pIvotX v2.0.0
+ * pIvotX v${pkg.version}
  * Lightweight 2D game library — Vanilla JS, TypeScript & React
  * (c) ${new Date().getFullYear()} ColonDev Community | MIT License
  * https://github.com/ColonDev-Community/pIvotX

--- a/src/react/components/ui.tsx
+++ b/src/react/components/ui.tsx
@@ -63,8 +63,12 @@ export interface PivotUIProps {
 
 /**
  * Hosts pIvotX UI widgets inside a <PivotCanvas>.
- * Creates a UIManager on the canvas and (unless `manual`) draws the UI every
- * animation frame after the game loop's rAF callback, so it stays on top.
+ *
+ * Place it as the LAST child so the UI draws on top: after every render it
+ * repaints the UI once the sibling shape components have drawn (this is what
+ * keeps it visible in games that re-render each frame with `autoClear`), and
+ * a rAF loop repaints between renders so hover/press/drag feedback stays
+ * live even in static scenes.
  */
 export function PivotUI({ manual = false, uiRef, children }: PivotUIProps) {
   const ctx = useCanvasContext();
@@ -90,8 +94,14 @@ export function PivotUI({ manual = false, uiRef, children }: PivotUIProps) {
       if (uiRef) uiRef.current = null;
       setManager(null);
     };
-     
+
   }, [ctx, manual]);
+
+  // Repaint after every render, once sibling shape effects have drawn —
+  // without this, autoClear games erase the UI between rAF repaints.
+  useEffect(() => {
+    if (!manual && manager) manager.draw(ctx);
+  });
 
   return manager ? (
     <UIManagerContext.Provider value={manager}>{children}</UIManagerContext.Provider>


### PR DESCRIPTION
# fix(react): PivotUI widgets erased by autoClear in per-frame-render games → 2.0.1

Patch release: the published 2.0.0 has a visibility bug in the React JSX UI
layer. Found by playtesting the docs site's live **V2 Playground** — the
joystick, jump button, and energy bar never appeared on screen.

## The bug

In games that re-render every frame (`useGameLoop` + `setState`) inside
`<PivotCanvas autoClear>`, the per-frame sequence was:

1. `<PivotUI>`'s rAF loop draws the widgets
2. the game loop's `setState` triggers a React render
3. `autoClear` wipes the canvas during the render phase
4. sibling shape effects redraw the world
5. **paint — the UI was erased in step 3 and never repainted**

So the widgets existed, hit-tested, and handled input — they just never
survived to the paint.

## The fix

`PivotUI` now **also repaints in a per-render effect**. React runs sibling
effects in JSX order, so with `<PivotUI>` placed as the last child (now
documented on the component), its repaint lands after the shape effects and
the UI stays on top:

- **per-frame-render games** → repainted every render, after the world
- **static scenes** → the existing rAF loop still keeps hover/press/drag
  feedback live between renders

No API changes; `manual` mode is unaffected.

## Release chore (second commit)

- `package.json` → **2.0.1** (2.0.0 is already published and immutable)
- CHANGELOG: 2.0.1 entry
- Rollup banner now reads the version from `package.json` — it was
  hardcoded `v2.0.0` and would have silently drifted on every release

## Verification

- lint / `tsc --noEmit` / all 11 bundles / **37/37 tests** pass
- Built bundles carry the correct `pIvotX v2.0.1` banner
- Verified visually in the docs site's V2 Playground (pivotx-docs branch
  `v2.0.0-docs`), which depends on this fix — widgets render and stay
  interactive at 60 fps with `autoClear`

## After merge

1. `git pull && npm publish` from master (`prepublishOnly` re-verifies)
2. `git tag v2.0.1 && git push origin v2.0.1`
3. Refresh the pivotx-docs lockfile (`^2.0.0` → resolves 2.0.1) and merge
   `v2.0.0-docs` — the live playground needs this patch to show its UI